### PR TITLE
Fix inconsistencies with ADM rule definitions

### DIFF
--- a/ietf-amm.yang
+++ b/ietf-amm.yang
@@ -174,7 +174,7 @@ module ietf-amm {
   }
 
   extension action {
-    argument exec-tgt; 
+    argument exec-tgt;
     description
       "Definition of the action executed by a rule object.
        The argument to this statement is the exec-tgt to execute.";

--- a/ietf-amm.yang
+++ b/ietf-amm.yang
@@ -190,19 +190,19 @@ module ietf-amm {
   extension min-interval {
     argument relative-time;
     description
-      "The argument to this statement defines a minimum amount of time between condition evaluations for an SBR object.";
+      "The argument to this statement is a time-based ARI specifying the minimum amount of time between condition evaluations for an SBR object.";
   }
 
   extension max-count {
     argument count;
     description
-      "The argument to this statement is the maximum execution count for a rule object.";
+      "The argument to this statement is the integer maximum execution count for a rule object.";
   }
 
   extension init-enabled {
     argument state;
     description
-      "The argument to this statement is the initial enabled state for a rule object.";
+      "The argument to this statement is the boolean initial enabled state for a rule object.";
   }
 
   extension tbr {
@@ -215,13 +215,13 @@ module ietf-amm {
   extension start {
     argument time;
     description
-      "The argument to this statement is the start time for a TBR object.";
+      "The argument to this statement is the start time ARI for a TBR object.";
   }
 
   extension period {
     argument relative-time;
     description
-      "The argument to this statement is the period for a TBR object.";
+      "The argument to this statement is an ARI defining the period for a TBR object.";
   }
 
   /*

--- a/ietf-amm.yang
+++ b/ietf-amm.yang
@@ -174,33 +174,35 @@ module ietf-amm {
   }
 
   extension action {
-    argument name;
+    argument exec-tgt; 
     description
-      "The argument is the action for a rule object.";
+      "Definition of the action executed by a rule object.
+       The argument to this statement is the exec-tgt to execute.";
   }
 
   extension condition {
-    argument name;
+    argument expr;
     description
-      "The argument is the condition for a SBR object.";
+      "Condition evaluated by an SBR object to determine whether to execute its action.
+       The argument to this statement is the expr to evaluate.";
   }
 
   extension min-interval {
-    argument name;
+    argument relative-time;
     description
-      "The argument is the condition for a SBR object.";
+      "The argument to this statement defines a minimum amount of time between condition evaluations for an SBR object.";
   }
 
   extension max-count {
-    argument name;
+    argument count;
     description
-      "The argument is the maximum execution count for a rule object.";
+      "The argument to this statement is the maximum execution count for a rule object.";
   }
 
   extension init-enabled {
-    argument name;
+    argument state;
     description
-      "The argument is the initial enabled state for a rule object.";
+      "The argument to this statement is the initial enabled state for a rule object.";
   }
 
   extension tbr {
@@ -211,15 +213,15 @@ module ietf-amm {
   }
 
   extension start {
-    argument name;
+    argument time;
     description
-      "The argument is the start time for a TBR object.";
+      "The argument to this statement is the start time for a TBR object.";
   }
 
   extension period {
-    argument name;
+    argument relative-time;
     description
-      "The argument is the period for a TBR object.";
+      "The argument to this statement is the period for a TBR object.";
   }
 
   /*

--- a/ietf-amm.yang
+++ b/ietf-amm.yang
@@ -166,6 +166,62 @@ module ietf-amm {
        The argument to this statement is the object name.";
   }
 
+  extension sbr {
+    argument name;
+    description
+      "Definition of a SBR within an ADM.
+       The argument to this statement is the object name.";
+  }
+
+  extension action {
+    argument name;
+    description
+      "The argument is the action for a rule object.";
+  }
+
+  extension condition {
+    argument name;
+    description
+      "The argument is the condition for a SBR object.";
+  }
+
+  extension min-interval {
+    argument name;
+    description
+      "The argument is the condition for a SBR object.";
+  }
+
+  extension max-count {
+    argument name;
+    description
+      "The argument is the maximum execution count for a rule object.";
+  }
+
+  extension init-enabled {
+    argument name;
+    description
+      "The argument is the initial enabled state for a rule object.";
+  }
+
+  extension tbr {
+    argument name;
+    description
+      "Definition of a TBR within an ADM.
+       The argument to this statement is the object name.";
+  }
+
+  extension start {
+    argument name;
+    description
+      "The argument is the start time for a TBR object.";
+  }
+
+  extension period {
+    argument name;
+    description
+      "The argument is the period for a TBR object.";
+  }
+
   /*
    * This section contains extensions for defining semantic type instances.
    */

--- a/ietf-dtnma-agent.yang
+++ b/ietf-dtnma-agent.yang
@@ -611,6 +611,9 @@ module ietf-dtnma-agent {
       amm:column max-count {
         amm:type "/ARITYPE/UVAST";
       }
+      amm:column enabled {
+        amm:type "/ARITYPE/BOOL";
+      }
     }
   }
   amm:edd tbr-list {
@@ -637,6 +640,9 @@ module ietf-dtnma-agent {
       }
       amm:column max-count {
         amm:type "/ARITYPE/UVAST";
+      }
+      amm:column enabled {
+        amm:type "/ARITYPE/BOOL";
       }
     }
   }

--- a/ietf-dtnma-agent.yang
+++ b/ietf-dtnma-agent.yang
@@ -591,6 +591,7 @@ module ietf-dtnma-agent {
     amm:enum 12;
     description
       "A table of SBR within the agent.";
+    uses obj-list-params;
     amm:tblt {
       amm:key "obj";
       amm:column obj {
@@ -600,9 +601,6 @@ module ietf-dtnma-agent {
         description
           "The execution when this rule triggers.";
         amm:type "//ietf/amm/TYPEDEF/MAC";
-      }
-      amm:column start-time {
-        amm:type "//ietf/amm/TYPEDEF/TIME";
       }
       amm:column condition {
         amm:type "//ietf/amm/TYPEDEF/EXPR";
@@ -620,6 +618,7 @@ module ietf-dtnma-agent {
     amm:enum 13;
     description
       "A table of TBR within the agent.";
+    uses obj-list-params;
     amm:tblt {
       amm:key "obj";
       amm:column obj {

--- a/ietf-dtnma-agent.yang
+++ b/ietf-dtnma-agent.yang
@@ -522,10 +522,10 @@ module ietf-dtnma-agent {
       amm:type "//ietf/amm/TYPEDEF/EXPR";
     }
   }
-  amm:ctrl discard-const {
+  amm:ctrl obsolete-const {
     amm:enum 12;
     description
-      "Discard a specific CONST if it is present.";
+      "Mark a specific CONST as obsolete if it is present.";
     amm:parameter obj {
       description
         "A reference to a CONST within an ODM only.";


### PR DESCRIPTION
Remove start time from `sbr-list` since it is not applicable for SBR's.

Add `obj-list param` for `sbr-list` and `tbr-list` to be consistent with "list" EDD's for other types.