### PR TITLE
Fix regex pattern unnecessary escaping for CAMP PR

### DIFF
--- a/ietf-amm-base.yang
+++ b/ietf-amm-base.yang
@@ -221,7 +221,7 @@ module ietf-amm-base {
     reference
       "draft-ietf-dtn-amm";
     amm:type "/ARITYPE/textstr" {
-      pattern '[A-Za-z_][0-9A-Za-z_\-\.]*';
+      pattern '[A-Za-z_][0-9A-Za-z_.-]*';
     }
   }
   amm:typedef id-int {


### PR DESCRIPTION
CAMP constraints PR fails because of this