### PR TITLE
Fix unions to support evaluation testing

### DIFF
--- a/ietf-amm-base.yang
+++ b/ietf-amm-base.yang
@@ -112,7 +112,7 @@ module ietf-amm-base {
   amm:typedef integer {
     amm:enum 1;
     description
-      "Any type which represents a discrete integer
+      "Any type which represents a discrete integer.
        This union order prefers smaller range and signed types.";
     amm:union {
       amm:type "/ARITYPE/byte";
@@ -125,7 +125,8 @@ module ietf-amm-base {
   amm:typedef float {
     amm:enum 2;
     description
-      "Any type which represents a floating point number.";
+      "Any type which represents a floating point number.
+       This union order prefers smaller range.";
     amm:union {
       amm:type "/ARITYPE/real32";
       amm:type "/ARITYPE/real64";
@@ -143,13 +144,15 @@ module ietf-amm-base {
   amm:typedef primitive {
     amm:enum 4;
     description
-      "Any primitive type.";
+      "Any primitive type.
+       This union order prefers conversion to wide types.";
     amm:union {
-      amm:type "/ARITYPE/null";
-      amm:type "/ARITYPE/bool";
       amm:type "./TYPEDEF/numeric";
       amm:type "/ARITYPE/textstr";
       amm:type "/ARITYPE/bytestr";
+      amm:type "/ARITYPE/bool";
+      // null is last option for conversion
+      amm:type "/ARITYPE/null";
     }
   }
   amm:typedef time {
@@ -166,8 +169,8 @@ module ietf-amm-base {
     description
       "Any type which contains a single literal value (not nested).";
     amm:union {
-      amm:type "./TYPEDEF/PRIMITIVE";
       amm:type "./TYPEDEF/TIME";
+      amm:type "./TYPEDEF/PRIMITIVE";
     }
   }
   amm:typedef nested {
@@ -328,13 +331,13 @@ module ietf-amm-base {
     description
       "Each item of an EXPR list.";
     amm:union {
-      amm:type "./TYPEDEF/simple";
+      // plain value for the stack
+      amm:type "/ARITYPE/literal";
       // object which produces an eval-tgt
       amm:type "./TYPEDEF/value-obj";
       // treated as unary operator
       amm:type "./TYPEDEF/type-ref";
-      // substitutable label of an external context value
-      amm:type "/ARITYPE/label";
+      // operator to evaluate
       amm:type "/ARITYPE/oper";
     }
   }

--- a/ietf-amm-base.yang
+++ b/ietf-amm-base.yang
@@ -320,7 +320,7 @@ module ietf-amm-base {
        SHALL produce a value that matches <./typedef/expr>, which
        is then evaluated.";
     amm:union {
-      // object which produces an eval-tgt
+      // object which produces an expression
       amm:type "./TYPEDEF/value-obj";
       // inline expression
       amm:type "./TYPEDEF/expr";
@@ -333,10 +333,8 @@ module ietf-amm-base {
     amm:union {
       // plain value for the stack
       amm:type "/ARITYPE/literal";
-      // object which produces an eval-tgt
+      // object which produces a value for the stack
       amm:type "./TYPEDEF/value-obj";
-      // treated as unary operator
-      amm:type "./TYPEDEF/type-ref";
       // operator to evaluate
       amm:type "/ARITYPE/oper";
     }


### PR DESCRIPTION
Descriptions are updated to explain ordering.
This relaxes `expr-item` to allow any literal value for the evaluation stack.