### PR TITLE
The any typedef did not allow namespace

### DIFF
--- a/ietf-amm-base.yang
+++ b/ietf-amm-base.yang
@@ -201,6 +201,7 @@ module ietf-amm-base {
     amm:union {
       amm:type "/ARITYPE/literal";
       amm:type "/ARITYPE/object";
+      amm:type "/ARITYPE/namespace";
     }
   }
   amm:typedef value-obj {


### PR DESCRIPTION
This causes issues in many ctrls and opers.